### PR TITLE
Updating examples with suggestion of left_margin 

### DIFF
--- a/examples/plotting_interferometer.ipynb
+++ b/examples/plotting_interferometer.ipynb
@@ -25,7 +25,7 @@
     "using Pkg\n",
     "Pkg.activate(\"./\")\n",
     "Pkg.add(url=\"git@github.com:ProjectTorreyPines/OMAS.jl.git\")\n",
-    "Pkg.add(url=\"git@github.com:ProjectTorreyPines/GGDUtils.jl.git\", ver=\"dev\")\n",
+    "Pkg.add(url=\"git@github.com:ProjectTorreyPines/GGDUtils.jl.git\")\n",
     "Pkg.add(\"Plots\")"
    ]
   },
@@ -77,7 +77,7 @@
     "\n",
     "plot(space)\n",
     "plot!(ids.interferometer) # Default plot_type is :los \n",
-    "plot!(legend=true)"
+    "plot!(legend=true, left_margin=10Plots.pt)"
    ]
   },
   {
@@ -99,7 +99,7 @@
     "\n",
     "plot(space)\n",
     "plot!(ids.interferometer, mirror_length=0.7, linewidth=4, mirror_thickness=0.2)\n",
-    "plot!(legend=true)"
+    "plot!(legend=true, left_margin=10Plots.pt)"
    ]
   },
   {
@@ -121,7 +121,7 @@
     "\n",
     "plot(space)\n",
     "plot!(ids.interferometer, mirror=false)\n",
-    "plot!(legend=true)"
+    "plot!(legend=true, left_margin=10Plots.pt)"
    ]
   },
   {
@@ -143,7 +143,7 @@
     "\n",
     "plot(space)\n",
     "plot!(ids.interferometer.channel[1], label=\"Channel 1\")\n",
-    "plot!(legend=true)"
+    "plot!(legend=true, left_margin=10Plots.pt)"
    ]
   },
   {
@@ -166,7 +166,7 @@
     "gr()           # Fast and can save pdf\n",
     "# plotlyjs()   # Use for interactive plot, can only save png\n",
     "\n",
-    "plot(ids.interferometer, plot_type=:n_e)"
+    "plot(ids.interferometer, plot_type=:n_e, left_margin=10Plots.pt)"
    ]
   },
   {
@@ -179,7 +179,7 @@
     "gr()           # Fast and can save pdf\n",
     "# plotlyjs()   # Use for interactive plot, can only save png\n",
     "\n",
-    "plot(ids.interferometer, plot_type=:n_e_average)"
+    "plot(ids.interferometer, plot_type=:n_e_average, left_margin=10Plots.pt)"
    ]
   },
   {
@@ -199,7 +199,28 @@
     "gr()           # Fast and can save pdf\n",
     "# plotlyjs()   # Use for interactive plot, can only save png\n",
     "\n",
-    "plot(ids.interferometer.channel[1], plot_type=:n_e_average)"
+    "plot(ids.interferometer.channel[1], plot_type=:n_e_average, left_margin=10Plots.pt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting the interferometer geometry on top of 2D property data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gr()\n",
+    "\n",
+    "n_e = GGDUtils.get_prop_with_grid_subset_index(ids.edge_profiles.ggd[1].electrons.density, 5)\n",
+    "plot(ids.edge_profiles.grid_ggd, n_e, colorbar_title=\"Electrons density / m^(-3)\", left_margin=10Plots.pt)\n",
+    "plot!(space)\n",
+    "plot!(ids.interferometer, legend=true, size=[635, 900]) # Adding a size comment to make plot aspect ratio better"
    ]
   }
  ],


### PR DESCRIPTION
Left margin should be set to not clip the yaxis labels.
Interferometer can be overlaid on top of 2d heatmap of quantities with https://github.com/ProjectTorreyPines/GGDUtils.jl/pull/35 accepted. Added an example of this new change as well.