### PR TITLE
Added dribble option in gas injection

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,8 +191,9 @@ function test_gas_response(config, excitation, plot_title, figname; fit=false)
             get_gas_injection_response(cmd, cmd_tt, P_ves, P_ves_tt, V_ves)
         ids.gas_injection.valve[1].response_curve = gasd_resp_curve
         # Adding made up time_constant and damping
-        gasd_model[:time_constant] = 0.3
-        gasd_model[:damping] = 0.8
+        gasd_model[:time_constant] = 0.05
+        gasd_model[:damping] = 0.5
+        gasd_model[:dribble_decay_time_constant] = 0.45
 
         valves = Dict("GASD" => gasd_model)
 
@@ -227,7 +228,8 @@ function test_gas_response(config, excitation, plot_title, figname; fit=false)
         # Setting special latency for GASD, GASA will follow global latency
         valves = Dict{String, Dict{Symbol, Any}}(
             "GASD" =>
-                Dict(:latency => 0.183, :time_constant => 0.3, :damping => 0.8),
+                Dict(:latency => 0.183, :time_constant => 0.05, :damping => 0.5,
+                    :dribble_decay_time_constant => 0.45),
         )
     end
 


### PR DESCRIPTION
If :dribble_decay_time_constant is present in the valve dictionary of the gas model, the flow rate will be modified to not let it decay faster than the given time constant based exponential decay. This models the valves that have long pipes.

Following are the test results when dribble decay time constant of 0.45 seconds was added GAS D valve. This number is based on rough fitting from GASD valve pressure data for the calibration shots.

![gas_injection_noise](https://github.com/ProjectTorreyPines/SynthDiag.jl/assets/29802951/644cd1ef-5a94-444d-a0f4-ee4a3e8eaf52)
![gas_injection_sine_noise](https://github.com/ProjectTorreyPines/SynthDiag.jl/assets/29802951/42f52c5b-83a9-4647-8a09-3c96ed6125c3)
![gas_injection_sine](https://github.com/ProjectTorreyPines/SynthDiag.jl/assets/29802951/4dccd418-371d-442a-9840-aa79c3e4a7dd)
![gas_injection_start_stop](https://github.com/ProjectTorreyPines/SynthDiag.jl/assets/29802951/a4f0f158-f538-4304-a4b7-c1cf911045af)
![gas_injection_step](https://github.com/ProjectTorreyPines/SynthDiag.jl/assets/29802951/309cb842-b037-4e66-abee-37c878e82fff)

Note the initial oscillations and overshoot are modeled as an overdamped second-order filter. This is observed in calibration shot gas valve pressure readings too.

