### PR TITLE
Updates in gas injection for more modularity and clarity

### DIFF
--- a/src/gas_injection.jl
+++ b/src/gas_injection.jl
@@ -1,4 +1,4 @@
-import Interpolations: linear_interpolation
+import Interpolations: linear_interpolation, Flat
 import DSP.Filters: Biquad, bilinear, convert, SecondOrderSections, DF2TFilter
 import DSP: filt, xcorr
 import LsqFit: curve_fit, coef
@@ -216,7 +216,8 @@ function compute_gas_injection(
     flow_rate = zeros(length(tt))
     valve_response = linear_interpolation(
         response_curve_voltage,
-        response_curve_flow_rate,
+        response_curve_flow_rate;
+        extrapolation_bc=Flat(),
     )
     tt_over_lat = findall(x -> x >= latency + tt[1], tt)
     if length(tt_over_lat) > 0

--- a/src/gas_injection.jl
+++ b/src/gas_injection.jl
@@ -183,7 +183,7 @@ function compute_gas_injection(
             tt_over_lat = findall(x -> x > latency + tt0, valve.voltage.time)
             if length(tt_over_lat) > 0
                 skip = tt_over_lat[1]
-                flow_rate[skip:end] = valve_response.(valve.voltage.data[1:end-skip+1])
+                flow_rate = valve_response.(valve.voltage.data)
                 if !isnothing(dribble_tau)
                     flow_rate = dribble(
                         flow_rate,
@@ -195,6 +195,8 @@ function compute_gas_injection(
                     flow_rate = filt(LPF, flow_rate)
                 end
                 flow_rate = map((x)::Float64 -> x < 0.0 ? 0.0 : x, flow_rate)
+                flow_rate[1:skip-1] .= 0.0
+                flow_rate[skip:end] = flow_rate[1:end-skip+1]
             end
             valve.flow_rate.data = flow_rate
         end

--- a/src/gas_injection.jl
+++ b/src/gas_injection.jl
@@ -238,12 +238,14 @@ function dribble(
 )::Vector{Float64}
     data_der = [diff(data); 0.0]
     ii = 1
-    while ii < length(data_der) - 2
+    while ii < length(data_der) - 1
         if data_der[ii] <
            -exp(-1.0 / (decay_time_constant * fs)) / (decay_time_constant * fs)
             data[ii+1] = data[ii] * exp(-1.0 / (decay_time_constant * fs))
             data_der[ii] = data[ii+1] - data[ii]
-            data_der[ii+1] = data[ii+2] - data[ii+1]
+            if ii < length(data_der) - 2
+                data_der[ii+1] = data[ii+2] - data[ii+1]
+            end
         end
         ii += 1
     end
@@ -433,4 +435,20 @@ function get_gas_injection_response(
     valve_model = Dict{Symbol, Any}(:latency => latency)
 
     return response_curve, valve_model
+end
+
+function get_required_gas_cmd(
+    required_flow_rate::Float64,
+    response_curve::IMASDD.gas_injection__valve___response_curve,
+)::Float64
+    gas_cmd = linear_interpolation(response_curve.flow_rate, response_curve.voltage)
+    return gas_cmd(required_flow_rate)
+end
+
+function get_required_gas_cmd(
+    required_flow_rate::Vector{Float64},
+    response_curve::IMASDD.gas_injection__valve___response_curve,
+)::Vector{Float64}
+    gas_cmd = linear_interpolation(response_curve.flow_rate, response_curve.voltage)
+    return gas_cmd.(required_flow_rate)
 end

--- a/src/gas_injection.jl
+++ b/src/gas_injection.jl
@@ -92,7 +92,7 @@ function add_gas_injection!(
     valves = Dict{String, Dict{Symbol, Any}}(
         valve[:name] => valve for valve ∈ config[:gas_injection][:valve]
     )
-    compute_gas_injection(ids; valves=valves)
+    compute_gas_injection!(ids; valves=valves)
     return ids
 end
 
@@ -101,7 +101,7 @@ end
 
 Compute the gas flow rate based on the command signal in the gas valves.
 """
-function compute_gas_injection(
+function compute_gas_injection!(
     ids::IMASDD.dd;
     valves::Dict{String, Dict{Symbol, Any}}=Dict{String, Dict{Symbol, Any}}(),
 )
@@ -165,53 +165,6 @@ function compute_gas_injection(
                 valve_model=valve_model,
                 global_latency=global_latency,
             )
-            # latency = deepcopy(global_latency)
-            # LPF = nothing
-            # dribble_tau = nothing
-            # if valve.name ∈ keys(valves)
-            #     valve_model = valves[valve.name]
-            #     if :latency ∈ keys(valve_model)
-            #         latency = valve_model[:latency]
-            #     end
-            #     if :time_constant ∈ keys(valve_model) && :damping ∈ keys(valve_model)
-            #         LPF = get_lpf(
-            #             1 / (valve.voltage.time[2] - valve.voltage.time[1]),
-            #             valve_model[:time_constant],
-            #             valve_model[:damping],
-            #             1.0,
-            #         )
-            #     end
-            #     if :dribble_decay_time_constant ∈ keys(valve_model)
-            #         dribble_tau = valve_model[:dribble_decay_time_constant]
-            #     end
-            # end
-            # valve.flow_rate.time = valve.voltage.time
-            # flow_rate = zeros(length(valve.voltage.time))
-            # valve_response = linear_interpolation(
-            #     valve.response_curve.voltage,
-            #     valve.response_curve.flow_rate,
-            # )
-            # tt0 = valve.voltage.time[1]
-            # tt_over_lat = findall(x -> x >= latency + tt0, valve.voltage.time)
-            # if length(tt_over_lat) > 0
-            #     skip = tt_over_lat[1]
-            #     flow_rate = valve_response.(valve.voltage.data)
-            #     if !isnothing(dribble_tau)
-            #         flow_rate = dribble(
-            #             flow_rate,
-            #             dribble_tau,
-            #             1 / (valve.voltage.time[2] - valve.voltage.time[1]),
-            #         )
-            #     end
-            #     if !isnothing(LPF)
-            #         flow_rate = filt(LPF, flow_rate)
-            #     end
-            #     flow_rate = map((x)::Float64 -> x < 0.0 ? 0.0 : x, flow_rate)
-            #     future_flow_rates[vind] = flow_rate[end-skip+2:end]
-            #     flow_rate[1:skip-1] .= 0.0
-            #     flow_rate[skip:end] = flow_rate[1:end-skip+1]
-            # end
-            # valve.flow_rate.data = flow_rate
         end
     end
     return future_flow_rates

--- a/src/interferometer.jl
+++ b/src/interferometer.jl
@@ -87,7 +87,7 @@ function add_interferometer!(
             )
     end
     IMASDD.dict2imas(config, ids; verbose=verbose)
-    compute_interferometer(ids; rtol=rtol, n_e_gsi=n_e_gsi)
+    compute_interferometer!(ids; rtol=rtol, n_e_gsi=n_e_gsi)
     return ids
 end
 
@@ -97,7 +97,7 @@ end
   - Calculate phase_to_n_e_line if not present for each wavelength
   - Compute the line integrated electron density if not present
 """
-function compute_interferometer(
+function compute_interferometer!(
     @nospecialize(ids::IMASDD.dd);
     rtol::Float64=1e-3,
     n_e_gsi::Int=5,

--- a/src/langmuir_probes.jl
+++ b/src/langmuir_probes.jl
@@ -28,7 +28,6 @@ function add_langmuir_probes!(
     else
         error("Only JSON files are supported.")
     end
-    compute_langmuir_probes(ids; kwargs...)
     return ids
 end
 
@@ -120,11 +119,11 @@ function add_langmuir_probes!(
             )
     end
     IMASDD.dict2imas(config, ids; verbose=verbose)
-    compute_langmuir_probes(ids; kwargs...)
+    compute_langmuir_probes!(ids; kwargs...)
     return ids
 end
 
-function compute_langmuir_probes(
+function compute_langmuir_probes!(
     ids::IMASDD.dd;
     v_plasma::Union{Float64, Vector{Float64}, Nothing}=nothing,
     v_floating::Union{Float64, Vector{Float64}, Nothing}=nothing,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using SynthDiag: IMASDD, add_interferometer!, add_langmuir_probes!, add_gas_injection!,
-    compute_gas_injection, get_gas_injection_response, Noise, OverwriteAttemptError,
+    compute_gas_injection!, get_gas_injection_response, Noise, OverwriteAttemptError,
     langmuir_probe_current
 using IMASDD: json2imas
 using Test
@@ -265,7 +265,7 @@ function test_gas_response(config, excitation, plot_title, figname; fit=false)
         )
     end
 
-    compute_gas_injection(ids; valves=valves)
+    compute_gas_injection!(ids; valves=valves)
 
     plot(;
         title=plot_title,


### PR DESCRIPTION
* Dribble model now correctly operate of the data till the last data point
* Latency operation happens after processing all the gas injection data
* compute functions in gas injection, interferometer, and langmuir probes have been changed in name to reflect inplace operations versus return value operations.
* compute_gas_injection is overloaded with many forms to allow use without ids and deal in base julia types. This helps in quick modeling and is particularly helpful in model predictive controllers.