### PR TITLE
 Using reusable workflows; remove dev from trigger

### DIFF
--- a/.github/workflows/compat_helper.yml
+++ b/.github/workflows/compat_helper.yml
@@ -2,22 +2,12 @@ name: CompatHelper
 on:
   schedule:
     - cron: '37 3 * * *'
+  push:
+    branches: reuse_ci
+    paths:
+      - '.github/workflows/format_check.yml'
+      - 'Project.toml'
   workflow_dispatch:
 jobs:
   CompatHelper:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Add the FuseRegistry via Git"
-        run: |
-          using Pkg
-          ENV["JULIA_PKG_SERVER"] = ""
-          Pkg.Registry.add(RegistrySpec(url="https://github.com/ProjectTorreyPines/FuseRegistry.jl.git"))
-          Pkg.Registry.add("General")
-        shell: julia --color=yes {0}
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main(;master_branch="dev")'
+    uses: ProjectTorreyPines/GitHubActionsWorkflows/.github/workflows/compat_helper.yml@master

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -2,42 +2,15 @@ name: Format Check
 
 on:
   push:
-    branches: ["master", "dev", "format"]
+    branches: ["master", "reuse_ci"]
     paths:
       - '.github/workflows/format_check.yml'
       - '**.jl'
   pull_request:
-    branches: ["master", "dev"]
+    branches: ["master"]
     paths:
       - '.github/workflows/format_check.yml'
       - '**.jl'
 jobs:
-  check:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.x]
-        julia-arch: [x64]
-        os: [ubuntu-latest]
-    steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.julia-version }}
-
-      - uses: actions/checkout@v1
-      - name: Install JuliaFormatter and format
-        run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
-          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
-      - uses: julia-actions/cache@v1
-      - name: Format check
-        run: |
-          julia -e '
-          out = Cmd(`git diff --name-only`) |> read |> String
-          if out == ""
-              exit(0)
-          else
-              @error "Some files have not been formatted !!!"
-              write(stdout, out)
-              exit(1)
-          end'
+  format_check: 
+    uses: ProjectTorreyPines/GitHubActionsWorkflows/.github/workflows/format_check.yml@master

--- a/.github/workflows/make_docs.yml
+++ b/.github/workflows/make_docs.yml
@@ -1,47 +1,20 @@
 name: Make Docs
 on:
-  pull_request:
-    branches: ["master", "dev"]
-    paths:
-      - '.github/workflows/make_docs.yml'
-      - 'src/**'
-      - 'docs/**'
   push:
-    branches:
-      - master
-      - dev
-      - docs
+    branches: ["master", "reuse_ci"]
     paths:
       - '.github/workflows/make_docs.yml'
       - 'src/**'
       - 'docs/**'
     tags: '*'
+  pull_request:
+    branches: ["master"]
+    paths:
+      - '.github/workflows/make_docs.yml'
+      - 'src/**'
+      - 'docs/**'
   workflow_dispatch:
     
 jobs:
   make_docs:
-    permissions:
-      contents: write
-      statuses: write
-    name: Documentation
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.x]
-        julia-arch: [x64]
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
-      - uses: julia-actions/cache@v1
-      - name: "Add the FuseRegistry via Git"
-        run: |
-          julia --project=docs/ -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url="https://github.com/ProjectTorreyPines/FuseRegistry.jl.git")); Pkg.Registry.add("General")'
-      - name: Install dependencies
-        run: |
-          julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=docs/ docs/make.jl
+    uses: ProjectTorreyPines/GitHubActionsWorkflows/.github/workflows/make_docs.yml@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,62 +2,29 @@ name: Test
 
 on:
   push:
-    branches: ["master", "dev", "autotest"]
+    branches: ["master", "reuse_ci"]
     paths:
       - '.github/workflows/test.yml'
       - 'src/**'
       - 'test/**'
       - 'Project.toml'
   pull_request:
-    branches: ["master", "dev"]
+    branches: ["master"]
     paths:
       - '.github/workflows/test.yml'
       - 'src/**'
       - 'test/**'
       - 'Project.toml'
 
-permissions:
-  actions: write
-  contents: read
-
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.x]
-        julia-arch: [x64]
-        os: [ubuntu-latest]
-    steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: actions/checkout@v4
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.SOLPSTESTSAMPLES_SSH_KEY}}
-            ${{ secrets.DVC_SSH_KEY }}
-      - name: Configure ssh
-        run: |
-          echo "${{ secrets.DVC_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
-          echo "${{ secrets.DVC_SSH_CONFIG }}" >> ~/.ssh/config
-      - uses: iterative/setup-dvc@v1
-      - name: DVC Pull
-        run: |
-          dvc pull
-      - uses: julia-actions/cache@v1
-      - name: "Add the FuseRegistry via Git"
-        run: |
-          julia --project=. -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url="https://github.com/ProjectTorreyPines/FuseRegistry.jl.git")); Pkg.Registry.add("General")'
-      - uses: julia-actions/julia-runtest@v1
-      - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v4
-        with:
-          name: test_result_images
-          path: test/*.png
-      # Not set up yet
-      # - uses: julia-actions/julia-processcoverage@v1
-      # - uses: codecov/codecov-action@v4
-      #   with:
-      #     files: lcov.info
+    uses: ProjectTorreyPines/GitHubActionsWorkflows/.github/workflows/test.yml@master
+    secrets: inherit
+    with:
+      upload_artifact: true
+      artifact_name: test_result_images
+      artifact_path: test/*.png
+    # Optional input to diable use of dvc for downloading sample files
+    # with:
+    #   use_dvc: false
+    # secrets: inherit can be removed in this case.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,6 @@ deploydocs(;
     repo="github.com/ProjectTorreyPines/SynthDiag.jl.git",
     target="build",
     branch="gh-pages",
-    devbranch="dev",
+    devbranch="master",
     versions=["stable" => "v^", "v#.#"],
 )


### PR DESCRIPTION
* Using reusable workflows from [GitHubActionsWorkflows](https://github.com/ProjectTorreyPines/GitHubActionsWorkflows)
* Remove dev from trigger list; from now on we'll directly merge with master as package versions are on registry
* Online documentation of development version will be made from master branch now.